### PR TITLE
Update GitHub stats image URLs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,10 +276,10 @@ const furkan01 = {
 <table>
   <tr>
     <td>
-      <img src="https://github-readme-stats.vercel.app/api/top-langs?username=mohdfurkan01&show_icons=true&locale=en&layout=compact" alt="Top Languages" style="height: 200px;" />
+      <img src="https://github-readme-stats-sigma-five.vercel.app/api/top-langs/?username=mohdfurkan01&layout=compact&theme=tokyonight&locale=en" alt="Top Languages" style="height: 200px;" />
     </td>
     <td>
-      <img src="https://github-readme-stats.vercel.app/api?username=mohdfurkan01&show_icons=true&locale=en" alt="GitHub Stats" />
+      <img src="https://github-readme-stats-sigma-five.vercel.app/api?username=mohdfurkan01&show_icons=true&theme=tokyonight&locale=en" alt="GitHub Stats" /> 
     </td>
     <td>
       <img src="https://github-readme-streak-stats.herokuapp.com/?user=mohdfurkan01" alt="GitHub Streak" />


### PR DESCRIPTION
info: public deployment itself is currently paused/down. examples: 
theme=radical
theme=dark
theme=onedark

show_icons=true  show icons
layout=compact for language card

steps:
These are:

NOT GitHub official features
They are third-party generated SVG images

So sometimes:
deployments go down
rate limits happen
mirrors change

That’s normal.

also search GitHub:

“github readme stats mirror”
“github stats vercel mirror”

People share active domains there.
Most common active one currently:

https://github-readme-stats-sigma-five.vercel.app

Most important thing

If one domain dies:
 replace only the domain with another active mirror.